### PR TITLE
Add support for previewing current record descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This plugin provides syntax highlighting and runtime support for [GNU Recutils](
   * Command wrappers for `recsel`, `recfix`, `recinf` and `rec2csv`.
   * Auto-completion of record set properties.
   * Record navigation commands and maps.
+  * Preview record descriptor in a popup/floating/preview window.
 
   See `help :recutils` for more information.
 
@@ -64,6 +65,7 @@ This plugin provides syntax highlighting and runtime support for [GNU Recutils](
   * `<localleader>rv` populates the Vim command line with `:Rec2csv`.
   * `<localleader>rN` jumps to the next record descriptor.
   * `<localleader>rP` jumps to the previous record descriptor..
+  * `<localleader>r?` show the current record descriptor in a popup/floating/preview window.
 
 ## Auto-completion
 

--- a/autoload/rec.vim
+++ b/autoload/rec.vim
@@ -240,11 +240,12 @@ function! s:ShowNeovimFloatingWindow(title, descriptor, linePosition) abort
   call nvim_buf_set_lines(l:descriptorBuffer, 0, -1, v:false, a:descriptor)
   call nvim_buf_set_option(l:descriptorBuffer, 'filetype', 'rec')
 
-  for key in ['q', '<Esc>', '<Leader>', '<CR>', '<C-C>']
-    call nvim_buf_set_keymap(l:descriptorBuffer, 'n', key, ':close<CR>', #{silent: v:true, noremap: v:true})
+  for key in ['q', '<Esc>', '<localleader>', '<CR>', '<C-C>']
+    call nvim_buf_set_keymap(l:descriptorBuffer, 'n', key, ':close<CR>', #{silent: v:true, noremap: v:true, nowait: v:true})
   endfor
 
   let windowId = nvim_open_win(descriptorBuffer, 1, s:NeovimPopupWindowOptions(a:title, a:descriptor, a:linePosition))
+  call win_execute(windowId, 'setlocal readonly')
 endfunction
 
 " Returns options specific to Neovim's popup windows.

--- a/autoload/rec.vim
+++ b/autoload/rec.vim
@@ -233,7 +233,7 @@ function! s:ShowNeovimFloatingWindow(title, descriptor, linePosition) abort
   call nvim_buf_set_lines(l:descriptorBuffer, 0, -1, v:false, a:descriptor)
   call nvim_buf_set_option(l:descriptorBuffer, 'filetype', 'rec')
 
-  for key in ['q', '<Esc>', '<Leader>', '<CR>']
+  for key in ['q', '<Esc>', '<Leader>', '<CR>', '<C-C>']
     call nvim_buf_set_keymap(l:descriptorBuffer, 'n', key, ':close<CR>', #{silent: v:true, noremap: v:true})
   endfor
 

--- a/autoload/rec.vim
+++ b/autoload/rec.vim
@@ -267,7 +267,6 @@ function! s:ShowPreviewWindow(descriptor) abort
   let filename = s:GetRecordDescriptorName(a:descriptor)
   let previewBuffer = bufadd(l:filename)
 
-  echom a:descriptor
   call bufload(l:previewBuffer)
   call deletebufline(l:previewBuffer, 1, '$')
   call appendbufline(l:previewBuffer, 1, a:descriptor)

--- a/doc/rec.txt
+++ b/doc/rec.txt
@@ -46,6 +46,8 @@ These |recutils-commands| maps are available in the |recutils| buffers only.
 <localleader>rv             Populates the command line with :Rec2csv
 <localleader>rN             Jump to the next record descriptor.
 <localleader>rP             Jump to the previous record descriptor.
+<localleader>r?             Show the current record descriptor in a
+                            popup/floating/preview window.
 
 The above maps can be disabled by setting the g:recutils_no_maps option.
 >

--- a/ftplugin/rec.vim
+++ b/ftplugin/rec.vim
@@ -53,6 +53,7 @@ command! -nargs=* Recfix call rec#Recfix(<f-args>)
 command! -nargs=* Rec2csv call rec#Rec2csv(<f-args>)
 command! -nargs=* RecPreviousDescriptor call rec#RecPreviousDescriptor()
 command! -nargs=* RecNextDescriptor call rec#RecNextDescriptor()
+command! RecPreviewDescriptor call rec#RecPreviewDescriptor()
 
 " Define command maps
 if !get(g:, 'recutils_no_maps')
@@ -62,6 +63,7 @@ if !get(g:, 'recutils_no_maps')
   nnoremap <buffer> <localleader>rv :Rec2csv<space>
   noremap <silent> <buffer> <localleader>rN :RecNextDescriptor<cr>
   noremap <silent> <buffer> <localleader>rP :RecPreviousDescriptor<cr>
+  noremap <silent> <buffer> <localleader>r? :RecPreviewDescriptor<cr>
 endif
 
 "" Enable auto-completion for record sets


### PR DESCRIPTION
Being able to see the current record descriptor without having to jump manually back and forth would make life easier when working with larger files.

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/39915/148490244-b56b4037-6cda-424c-aa2d-fc37eef780d9.png">

This PR adds support for previewing the current/active record descriptor in a popup window (on versions of Vim with +popupwin), a floating window on Neovim or falling back to using a preview window on older versions of Vim.

The popup window closes automatically in Vim if you hit any keystroke but you have to manually close it in Neovim by using any of the `q`, `<localleader>`, `ESC`, `Ctrl-C` keys.