### PR TITLE
Added help tags file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
The `doc/tags` uses relative tags depending on the location from which one uses
the `:helptags` command, (which is usually done automatically by plugin
managers). Having `doc/tags` in the `.gitignore` list is convenient, especially
when using git submodules to manage plugins.