### PR TITLE
Use older-style string concats when setting up undo_ftplugin

### DIFF
--- a/ftplugin/rec.vim
+++ b/ftplugin/rec.vim
@@ -52,7 +52,7 @@ endfunction
 if has('folding') && !get(g:, 'recutils_no_folding')
   setlocal foldmethod=expr
   setlocal foldexpr=GetRecFold(v:lnum)
-  let b:undo_ftplugin ..= ' | setlocal foldmethod< foldexpr<'
+  let b:undo_ftplugin .= ' | setlocal foldmethod< foldexpr<'
 endif
 
 " Define commands wrappers for GNU Recutils
@@ -73,19 +73,19 @@ if !get(g:, 'recutils_no_maps')
   noremap <silent> <buffer> <localleader>r] :RecNextDescriptor<cr>
   noremap <silent> <buffer> <localleader>r[ :RecPreviousDescriptor<cr>
   noremap <silent> <buffer> <localleader>r? :RecPreviewDescriptor<cr>
-  let b:undo_ftplugin ..= " | silent! execute 'nunmap <buffer> <localleader>rf'" ..
-	\                 " | silent! execute 'nunmap <buffer> <localleader>rn'" ..
-	\                 " | silent! execute 'nunmap <buffer> <localleader>rs'" ..
-	\                 " | silent! execute 'nunmap <buffer> <localleader>rv'" ..
-	\                 " | silent! execute 'unmap  <buffer> <localleader>r]'" ..
-	\                 " | silent! execute 'unmap  <buffer> <localleader>r['" ..
+  let b:undo_ftplugin .= " | silent! execute 'nunmap <buffer> <localleader>rf'" .
+	\                 " | silent! execute 'nunmap <buffer> <localleader>rn'" .
+	\                 " | silent! execute 'nunmap <buffer> <localleader>rs'" .
+	\                 " | silent! execute 'nunmap <buffer> <localleader>rv'" .
+	\                 " | silent! execute 'unmap  <buffer> <localleader>r]'" .
+	\                 " | silent! execute 'unmap  <buffer> <localleader>r['" .
 	\                 " | silent! execute 'unmap  <buffer> <localleader>r?'"
 endif
 
 "" Enable auto-completion for record sets
 if has('eval') && !get(g:, 'recutils_no_autocompletion')
   setlocal omnifunc=reccomplete#Complete
-  let b:undo_ftplugin ..= ' | setlocal omnifunc<'
+  let b:undo_ftplugin .= ' | setlocal omnifunc<'
 endif
 
 let &cpo = s:cpo_save


### PR DESCRIPTION
We are [seeing errors](https://github.com/zaid/vim-rec/pull/8#issuecomment-1247378320) when running under older versions of Vim (8.0.0197 for example) due to using the new style of string concatenations.

This PR changes the concatenations to use `.` instead of `..` which should fix the problem.