### PR TITLE
Added Vim compiler file

### DIFF
--- a/compiler/rec.vim
+++ b/compiler/rec.vim
@@ -2,7 +2,7 @@
 " Compiler:	rec
 
 if exists("current_compiler")
-    finish
+  finish
 endif
 let current_compiler = "rec"
 

--- a/compiler/rec.vim
+++ b/compiler/rec.vim
@@ -1,0 +1,15 @@
+" Vim Compiler File
+" Compiler:	rec
+
+if exists("current_compiler")
+    finish
+endif
+let current_compiler = "rec"
+
+if exists(":CompilerSet") != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+CompilerSet errorformat=%f:%l:\ %trror:\ %m
+CompilerSet errorformat+=%f:\ %l:\ %trror:\ %m
+exe 'CompilerSet makeprg=recfix\ '.substitute(shellescape(expand('%')), ' ', '\\ ', 'g')


### PR DESCRIPTION
Finding errors through `recfix` by running `:make` in Vim.

This makes use of Vim's `Quickfix` (see `:help quickfix`) functionality for
listing errors found and jumping to them in the file.